### PR TITLE
Add missing cyan var

### DIFF
--- a/schemes/GitHub Dark.sublime-color-scheme
+++ b/schemes/GitHub Dark.sublime-color-scheme
@@ -11,6 +11,7 @@
         "white": "#fff",
         "gray": "#fafbfc",
         "blue": "#79b8ff",
+        "cyan": "#173352",
         "green": "#85e89d",
         "yellow": "#fff5b1",
         "orange": "#ffab70",

--- a/schemes/GitHub Light.sublime-color-scheme
+++ b/schemes/GitHub Light.sublime-color-scheme
@@ -11,6 +11,7 @@
         "white": "#fff",
         "gray": "#24292e",
         "blue": "#005cc5",
+        "cyan": "#D3E7FC",
         "green": "#22863a",
         "yellow": "#dbab09",
         "orange": "#e36209",


### PR DESCRIPTION
@mauroreisvieira I am not 100% sure if the color is correct, but it's my best guess that cyan is `#173352` for dark theme and `#D3E7FC` for the light theme. 


In Dark theme, the variable cyan is missing. (L:45, 54)
In Light theme, the variable cyan is missing. (L:45, 54)