### PR TITLE
Fix `no such prop font.bold when matching auto_complete_label against auto_complete_label`

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -818,7 +818,6 @@ export const rules = [
         'font.face': 'var(fontFace)',
         'font.size': 'var(fontSizeSm)',
         'font.italic': true,
-        'font.bold': true,
         fg: 'var(autoCompleteForeground)',
         match_fg: 'var(autoCompleteMatchForeground)',
         selected_fg: 'var(autoCompleteSelectedForeground)',


### PR DESCRIPTION
This PR fixes the `no such prop font.bold when matching auto_complete_label against auto_complete_label` warning in the Sublime console.
I was able to reproduce and fix this error locally by copying and pasting the theme and removing `font.bold` from the rule.

<img width="1904" alt="Знімок екрана 2021-08-16 о 12 31 26" src="https://user-images.githubusercontent.com/471335/129557647-00599f34-0536-4f6d-965f-61dcfde04349.png">

Unfortunately, I couldn't regenerate the themes due to an npm error: `404 Not Found - GET https://registry.npmjs.org/@primer/primitives/-/primitives-4.6.0.tgz`, maybe I should bump the primer version 