### PR TITLE
Add overlay_control kind_info rule

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -671,6 +671,15 @@ export const rules = [
         class: 'quick_panel',
         parents: [
             {
+                class: 'overlay_control kind_info',
+            },
+        ],
+        row_padding: [0, 0, 0, 0],
+    },
+    {
+        class: 'quick_panel',
+        parents: [
+            {
                 class: 'overlay_control goto_symbol',
             },
         ],


### PR DESCRIPTION
Add `overlay_control kind_info` to remove unnecessary padding for items with kinds(like LSP Goto Symbol).

Before:

<img width="603" alt="before" src="https://user-images.githubusercontent.com/471335/178237599-1826d7d4-9147-4e23-96b5-1e10aebe4d76.png">

After:

<img width="596" alt="after" src="https://user-images.githubusercontent.com/471335/178237642-b4c65bfb-c445-4764-bada-97f4d89a7830.png">

This way the styling is aligned with the built-in Goto Symbol like dialogues
