### PR TITLE
Exclude development files from sublime-package files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Files and directories with the attribute export-ignore won’t be added to
+# archive files. See http://git-scm.com/docs/gitattributes for details.
+
+# Github
+/.github/       export-ignore
+/.gitattributes export-ignore
+/.gitignore     export-ignore
+
+# Development
+scripts/        export-ignore
+src/            export-ignore
+.eslintrc       export-ignore
+*.config.js     export-ignore
+packages.json   export-ignore
+tsconfig.json   export-ignore
+
+# Preview
+assets/         export-ignore
+examples/       export-ignore


### PR DESCRIPTION
This commit adds a .gitattributes file to specify resources/files, which should not be part of sublime-package files, installed by users.

This reduces installed package size from 3.6MB to 140kB.