### PR TITLE
Fix input control colors

### DIFF
--- a/Github.hidden-theme
+++ b/Github.hidden-theme
@@ -1042,7 +1042,7 @@
             "class": "text_line_control",
             "layer0.opacity": 1,
             "layer0.inner_margin": 1,
-            "layer0.tint": "var(background)",
+            "layer0.tint": "var(inputBackground)",
             "layer1.tint": "var(inputBorder)",
             "layer1.opacity": 1,
             "layer1.inner_margin": 1,
@@ -1051,7 +1051,7 @@
                 8,
                 12
             ],
-            "color_scheme_tint": "var(background)"
+            "color_scheme_tint": "var(inputBackground)"
         },
         {
             "class": "dropdown_button_control",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -894,13 +894,13 @@ export function getRules() {
             class: 'text_line_control',
             'layer0.opacity': 1.0,
             'layer0.inner_margin': 1,
-            'layer0.tint': 'var(background)',
+            'layer0.tint': 'var(inputBackground)',
             'layer1.tint': 'var(inputBorder)',
             'layer1.opacity': 1.0,
             'layer1.inner_margin': 1,
             'layer1.draw_center': false,
             content_margin: [8, 12],
-            color_scheme_tint: 'var(background)',
+            color_scheme_tint: 'var(inputBackground)',
         },
 
         // DROPDOWN

--- a/widgets/Widget - GitHub Dark Colorblind.sublime-settings
+++ b/widgets/Widget - GitHub Dark Colorblind.sublime-settings
@@ -1,4 +1,5 @@
 {
+    "color_scheme": "GitHub Dark Colorblind.sublime-color-scheme",
     "font_size": 12,
     "highlight_line": false,
     "draw_shadows": false,

--- a/widgets/Widget - GitHub Dark High Contrast.sublime-settings
+++ b/widgets/Widget - GitHub Dark High Contrast.sublime-settings
@@ -1,4 +1,5 @@
 {
+    "color_scheme": "GitHub Dark High Contrast.sublime-color-scheme",
     "font_size": 12,
     "highlight_line": false,
     "draw_shadows": false,

--- a/widgets/Widget - GitHub Dark.sublime-settings
+++ b/widgets/Widget - GitHub Dark.sublime-settings
@@ -1,4 +1,5 @@
 {
+    "color_scheme": "GitHub Dark.sublime-color-scheme",
     "font_size": 12,
     "highlight_line": false,
     "draw_shadows": false,

--- a/widgets/Widget - GitHub Dimmed.sublime-settings
+++ b/widgets/Widget - GitHub Dimmed.sublime-settings
@@ -1,4 +1,5 @@
 {
+    "color_scheme": "GitHub Dimmed.sublime-color-scheme",
     "font_size": 12,
     "highlight_line": false,
     "draw_shadows": false,

--- a/widgets/Widget - GitHub Light Colorblind.sublime-settings
+++ b/widgets/Widget - GitHub Light Colorblind.sublime-settings
@@ -1,4 +1,5 @@
 {
+    "color_scheme": "GitHub Light Colorblind.sublime-color-scheme",
     "font_size": 12,
     "highlight_line": false,
     "draw_shadows": false,

--- a/widgets/Widget - GitHub Light High Contrast.sublime-settings
+++ b/widgets/Widget - GitHub Light High Contrast.sublime-settings
@@ -1,4 +1,5 @@
 {
+    "color_scheme": "GitHub Light High Contrast.sublime-color-scheme",
     "font_size": 12,
     "highlight_line": false,
     "draw_shadows": false,

--- a/widgets/Widget - GitHub Light.sublime-settings
+++ b/widgets/Widget - GitHub Light.sublime-settings
@@ -1,4 +1,5 @@
 {
+    "color_scheme": "GitHub Light.sublime-color-scheme",
     "font_size": 12,
     "highlight_line": false,
     "draw_shadows": false,


### PR DESCRIPTION
Addresses some of #30

This commit...

1. fixes input control background color assignment
2. assign matching color schemes to widget controls, to ensure they always follow selected theme instead of user's color scheme.

   It avoids black input panels in white theme.

