### PR TITLE
Fix active quick panel row background color

### DIFF
--- a/GitHub Adaptive.sublime-theme
+++ b/GitHub Adaptive.sublime-theme
@@ -44,7 +44,7 @@
         "panelRowBackground": "color(var(foreground) blend(var(background) 5%)))",
         "panelRowForeground": "var(--foreground)",
         "panelRowLabelForeground": "var(--foreground)",
-        "panelRowSelectedBackground": "color(var(background) blend(var(foreground) 80%))",
+        "panelRowSelectedBackground": "color(var(background) blend(var(foreground) 90%))",
         "panelRowSelectedForeground": "var(--foreground)",
         "panelRowMatchForeground": "var(--accent)",
         "panelRowSelectedMatchForeground": "var(--accent)",

--- a/GitHub Dark Colorblind.sublime-theme
+++ b/GitHub Dark Colorblind.sublime-theme
@@ -44,7 +44,7 @@
         "panelRowBackground": "#010409",
         "panelRowForeground": "#c9d1d9",
         "panelRowLabelForeground": "#c9d1d9",
-        "panelRowSelectedBackground": "rgba(110,118,129,0.4)",
+        "panelRowSelectedBackground": "#21262d",
         "panelRowSelectedForeground": "#c9d1d9",
         "panelRowMatchForeground": "#388bfd",
         "panelRowSelectedMatchForeground": "#388bfd",

--- a/GitHub Dark High Contrast.sublime-theme
+++ b/GitHub Dark High Contrast.sublime-theme
@@ -44,7 +44,7 @@
         "panelRowBackground": "#010409",
         "panelRowForeground": "#f0f3f6",
         "panelRowLabelForeground": "#f0f3f6",
-        "panelRowSelectedBackground": "rgba(158,167,179,0.4)",
+        "panelRowSelectedBackground": "#272b33",
         "panelRowSelectedForeground": "#f0f3f6",
         "panelRowMatchForeground": "#409eff",
         "panelRowSelectedMatchForeground": "#409eff",

--- a/GitHub Dark.sublime-theme
+++ b/GitHub Dark.sublime-theme
@@ -44,7 +44,7 @@
         "panelRowBackground": "#010409",
         "panelRowForeground": "#e6edf3",
         "panelRowLabelForeground": "#e6edf3",
-        "panelRowSelectedBackground": "rgba(110,118,129,0.4)",
+        "panelRowSelectedBackground": "#21262d",
         "panelRowSelectedForeground": "#e6edf3",
         "panelRowMatchForeground": "#388bfd",
         "panelRowSelectedMatchForeground": "#388bfd",

--- a/GitHub Dimmed.sublime-theme
+++ b/GitHub Dimmed.sublime-theme
@@ -44,7 +44,7 @@
         "panelRowBackground": "#1c2128",
         "panelRowForeground": "#adbac7",
         "panelRowLabelForeground": "#adbac7",
-        "panelRowSelectedBackground": "rgba(99,110,123,0.4)",
+        "panelRowSelectedBackground": "#373e47",
         "panelRowSelectedForeground": "#adbac7",
         "panelRowMatchForeground": "#4184e4",
         "panelRowSelectedMatchForeground": "#4184e4",

--- a/GitHub Light Colorblind.sublime-theme
+++ b/GitHub Light Colorblind.sublime-theme
@@ -44,7 +44,7 @@
         "panelRowBackground": "#f6f8fa",
         "panelRowForeground": "#24292f",
         "panelRowLabelForeground": "#24292f",
-        "panelRowSelectedBackground": "rgba(175,184,193,0.2)",
+        "panelRowSelectedBackground": "#e2e5e9",
         "panelRowSelectedForeground": "#24292f",
         "panelRowMatchForeground": "#0969da",
         "panelRowSelectedMatchForeground": "#0969da",

--- a/GitHub Light High Contrast.sublime-theme
+++ b/GitHub Light High Contrast.sublime-theme
@@ -44,7 +44,7 @@
         "panelRowBackground": "#ffffff",
         "panelRowForeground": "#0e1116",
         "panelRowLabelForeground": "#0e1116",
-        "panelRowSelectedBackground": "rgba(172,182,192,0.2)",
+        "panelRowSelectedBackground": "#e2e5e9",
         "panelRowSelectedForeground": "#0e1116",
         "panelRowMatchForeground": "#0349b4",
         "panelRowSelectedMatchForeground": "#0349b4",

--- a/GitHub Light.sublime-theme
+++ b/GitHub Light.sublime-theme
@@ -44,7 +44,7 @@
         "panelRowBackground": "#f6f8fa",
         "panelRowForeground": "#1f2328",
         "panelRowLabelForeground": "#1f2328",
-        "panelRowSelectedBackground": "rgba(175,184,193,0.2)",
+        "panelRowSelectedBackground": "#e2e5e9",
         "panelRowSelectedForeground": "#1f2328",
         "panelRowMatchForeground": "#0969da",
         "panelRowSelectedMatchForeground": "#0969da",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -100,7 +100,11 @@ export function setVariables(theme: Primer): ThemeVariables {
         panelRowBackground: color.canvas.inset,
         panelRowForeground: color.fg.default,
         panelRowLabelForeground: color.fg.default,
-        panelRowSelectedBackground: color.neutral.muted,
+        panelRowSelectedBackground: buildThemeVariants({
+            light: '#e2e5e9',
+            dark: scale.gray[7],
+            adaptive: 'color(var(background) blend(var(foreground) 90%))',
+        }),,
         panelRowSelectedForeground: color.fg.default,
         panelRowMatchForeground: buildThemeVariants({
             light: scale.blue[5],


### PR DESCRIPTION
Addresses parts of #30

This commit uses selected tree items' background color for selected quick panel rows as both use same overall background.