### PR TITLE
fix: remove left sidebar border

### DIFF
--- a/Github.hidden-theme
+++ b/Github.hidden-theme
@@ -370,7 +370,7 @@
             "layer0.tint": "var(sidebarBackground)",
             "layer1.opacity": 1,
             "layer1.inner_margin": [
-                1,
+                0,
                 1,
                 1,
                 0

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -435,7 +435,7 @@ export function getRules() {
             'layer0.opacity': 1.0,
             'layer0.tint': 'var(sidebarBackground)',
             'layer1.opacity': 1.0,
-            'layer1.inner_margin': [1, 1, 1, 0],
+            'layer1.inner_margin': [0, 1, 1, 0],
             'layer1.draw_center': false,
             'layer1.tint': 'var(sidebarBorder)',
             content_margin: [1, 6, 1, 0],


### PR DESCRIPTION
This commit removes the left border of sidebar container, because neither of main menu, status bar or the right edge of the editor control specify a border at main window edges.

As e.g. Gnome doesn't render any window border, it was pretty obvious and off.

Windows 11 renders thin 1px borders around windows, which caused the left sidebar border to double up with it - also looks off a bit, as it seems to belong to main window border.