### PR TITLE
fix: reduce grid layout borders

### DIFF
--- a/Github.hidden-theme
+++ b/Github.hidden-theme
@@ -362,7 +362,7 @@
         {
             "class": "grid_layout_control",
             "border_color": "var(gridBorder)",
-            "border_size": 2
+            "border_size": 1
         },
         {
             "class": "sidebar_container",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -426,7 +426,7 @@ export function getRules() {
         {
             class: 'grid_layout_control',
             border_color: 'var(gridBorder)',
-            border_size: 2,
+            border_size: 1,
         },
 
         // SIDEBAR LABEL


### PR DESCRIPTION
Borders of sidebar, tabs and edit controls are 1px wide. Separating views in e.g. a 2x2 grid layout with borders of 2px create a feeling of inconsistency.

Hence reducing it to 1, also.

Unfortunately we can't avoid doubling up horizontal grid borders with tabset top border.