### PR TITLE
Fix tab control borders

### DIFF
--- a/Github.hidden-theme
+++ b/Github.hidden-theme
@@ -182,7 +182,7 @@
             "content_margin": 0,
             "connector_height": 0,
             "tint_index": 0,
-            "tab_overlap": 0,
+            "tab_overlap": 1,
             "tab_width": 80,
             "tab_height": 40,
             "mouse_wheel_switch": false,
@@ -200,7 +200,7 @@
             "layer2.texture": "",
             "layer2.tint": "var(tabBorder)",
             "layer2.inner_margin": [
-                0,
+                1,
                 1,
                 1,
                 1
@@ -229,7 +229,7 @@
             ],
             "layer1.tint": "var(tabActiveBackground)",
             "layer2.inner_margin": [
-                0,
+                1,
                 1,
                 1,
                 0
@@ -242,6 +242,21 @@
             ],
             "layer3.tint": "var(tabSelectedBorderBorder)",
             "tint_modifier": "transparent"
+        },
+        {
+            "class": "tab_control",
+            "attributes": [
+                "left"
+            ],
+            "settings": [
+                "hide_tab_scrolling_buttons"
+            ],
+            "layer2.inner_margin": [
+                0,
+                1,
+                1,
+                0
+            ]
         },
         {
             "class": "tab_label",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -321,7 +321,7 @@ export function getRules() {
             content_margin: 0,
             connector_height: 0,
             tint_index: 0,
-            tab_overlap: 0,
+            tab_overlap: 1,
             tab_width: 80,
             tab_height: 40,
             mouse_wheel_switch: false,
@@ -340,7 +340,7 @@ export function getRules() {
             'layer2.draw_center': false,
             'layer2.texture': '',
             'layer2.tint': 'var(tabBorder)',
-            'layer2.inner_margin': [0, 1, 1, 1],
+            'layer2.inner_margin': [1, 1, 1, 1],
             'layer2.opacity': 1,
 
             'layer3.draw_center': false,
@@ -356,13 +356,18 @@ export function getRules() {
             attributes: ['selected'],
             'layer1.tint': 'var(tabActiveBackground)',
 
-            'layer2.inner_margin': [0, 1, 1, 0],
+            'layer2.inner_margin': [1, 1, 1, 0],
 
             'layer3.inner_margin': [0, 1, 0, 0],
             'layer3.tint': 'var(tabSelectedBorderBorder)',
             tint_modifier: 'transparent',
         },
-
+        {
+            class: 'tab_control',
+            attributes: ['left'],
+            settings: ['hide_tab_scrolling_buttons'],
+            'layer2.inner_margin': [0, 1, 1, 0],
+        },
         {
             class: 'tab_label',
             'font.face': 'var(fontFace)',


### PR DESCRIPTION
This commit statically defines all relevant tab control borders; left, top, right and optionally bottom for inactive tabs.

It uses `tab_overlap: 1` to ensure vertical borders between tabs are rendered with 1px only.

Only left most tab control's left hand border is removed in case `hide_tab_scrolling_buttons` setting is set, to ensure not to double up tab border with outer window border or grid borders.

This change fixes ...

1. left most tab not having a border on its left to separate it from tab scroll buttons.
2. ensures borders between overlapping tabs on both left and right end are always maintained.