### PR TITLE
Fix panel and statusbar borders

### DIFF
--- a/Github.hidden-theme
+++ b/Github.hidden-theme
@@ -806,7 +806,12 @@
                 3
             ],
             "layer1.draw_center": false,
-            "layer1.inner_margin": 1,
+            "layer1.inner_margin": [
+                0,
+                1,
+                0,
+                0
+            ],
             "layer1.tint": "var(statusBarBorder)",
             "layer1.opacity": 1
         },

--- a/Github.hidden-theme
+++ b/Github.hidden-theme
@@ -1052,7 +1052,12 @@
             "layer0.tint": "var(panelControlBackground)",
             "layer0.opacity": 1,
             "layer1.draw_center": false,
-            "layer1.inner_margin": 1,
+            "layer1.inner_margin": [
+                0,
+                1,
+                0,
+                1
+            ],
             "layer1.tint": "var(panelControlBorder)",
             "layer1.opacity": 1,
             "content_margin": 1

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -705,7 +705,7 @@ export function getRules() {
             'layer0.tint': 'var(statusBarBackground)',
             content_margin: [8, 3, 8, 3],
             'layer1.draw_center': false,
-            'layer1.inner_margin': 1,
+            'layer1.inner_margin': [0, 1, 0, 0],
             'layer1.tint': 'var(statusBarBorder)',
             'layer1.opacity': 1.0,
         },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -888,7 +888,7 @@ export function getRules() {
             'layer0.tint': 'var(panelControlBackground)',
             'layer0.opacity': 1.0,
             'layer1.draw_center': false,
-            'layer1.inner_margin': 1,
+            'layer1.inner_margin': [0, 1, 0, 1],
             'layer1.tint': 'var(panelControlBorder)',
             'layer1.opacity': 1.0,
             content_margin: 1,


### PR DESCRIPTION
This PR...

1. removes left and right border of output panels to avoid them
   being doubled up with existing window borders.

2. keeps only top-border of statusbar.
   Status bar border settings are currently augmented by those from Adaptive/Default theme, but in case it changes, define correct border settings to maintain only top border. Anything else doesn't work well with OSs cutting client area to round window corners.

Related with PR https://github.com/mauroreisvieira/github-sublime-theme/pull/33.