### PR TITLE
Fix auto-completion popup

### DIFF
--- a/Github.hidden-theme
+++ b/Github.hidden-theme
@@ -1117,14 +1117,27 @@
             }
         },
         {
-            "class": "auto_complete_info",
-            "spacing": 8
+            "class": "auto_complete_popup",
+            "content_margin": 1,
+            "layer0.tint": "var(panelControlBorder)"
         },
         {
             "class": "auto_complete",
             "row_padding": 0,
-            "tint_index": 0,
-            "tint_modifier": "var(autoCompleteBackground)",
+            "tint_index": -1,
+            "layer0.tint": "var(autoCompleteBackground)",
+            "layer0.opacity": 1
+        },
+        {
+            "class": "table_row",
+            "layer0.tint": "var(autoCompleteSelectedBackground)",
+            "layer0.opacity": 0
+        },
+        {
+            "class": "table_row",
+            "attributes": [
+                "selected"
+            ],
             "layer0.opacity": 1
         },
         {
@@ -1139,6 +1152,21 @@
             "fg_blend": true
         },
         {
+            "class": "auto_complete_hint",
+            "opacity": 0.7,
+            "font.italic": true
+        },
+        {
+            "class": "auto_complete_detail_pane",
+            "tint_index": -1,
+            "layer0.tint": "var(autoCompleteBackground)",
+            "layer0.opacity": 1
+        },
+        {
+            "class": "auto_complete_info",
+            "spacing": 8
+        },
+        {
             "class": "auto_complete_kind_name_label",
             "font.italic": true,
             "border_color": "color(var(accent) a(0.8))"
@@ -1148,21 +1176,14 @@
             "font.italic": true
         },
         {
-            "class": "auto_complete_hint",
-            "opacity": 0.7,
-            "font.italic": true
+            "class": "kind_container",
+            "layer0.opacity": 0,
+            "layer1.opacity": 0
         },
         {
-            "class": "table_row",
-            "layer0.tint": "var(autoCompleteSelectedBackground)",
-            "layer0.opacity": 0
-        },
-        {
-            "class": "table_row",
-            "attributes": [
-                "selected"
-            ],
-            "layer0.opacity": 1
+            "class": "kind_label",
+            "font.bold": false,
+            "font.italic": false
         },
         {
             "class": "button_control",

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -947,14 +947,25 @@ export function getRules() {
 
         // AUTO COMPLETE
         {
-            class: 'auto_complete_info',
-            spacing: 8,
+            class: 'auto_complete_popup',
+            content_margin: 1,
+            'layer0.tint': 'var(panelControlBorder)',
         },
         {
             class: 'auto_complete',
             row_padding: 0,
-            tint_index: 0,
-            tint_modifier: 'var(autoCompleteBackground)',
+            tint_index: -1,
+            'layer0.tint': 'var(autoCompleteBackground)',
+            'layer0.opacity': 1.0,
+        },
+        {
+            class: 'table_row',
+            'layer0.tint': 'var(autoCompleteSelectedBackground)',
+            'layer0.opacity': 0,
+        },
+        {
+            class: 'table_row',
+            attributes: ['selected'],
             'layer0.opacity': 1.0,
         },
         {
@@ -969,6 +980,22 @@ export function getRules() {
             fg_blend: true,
         },
         {
+            class: 'auto_complete_hint',
+            opacity: 0.7,
+            'font.italic': true,
+        },
+
+        {
+            class: 'auto_complete_detail_pane',
+            tint_index: -1,
+            'layer0.tint': 'var(autoCompleteBackground)',
+            'layer0.opacity': 1.0,
+        },
+        {
+            class: 'auto_complete_info',
+            spacing: 8,
+        },
+        {
             class: 'auto_complete_kind_name_label',
             'font.italic': true,
             border_color: 'color(var(accent) a(0.8))',
@@ -977,20 +1004,17 @@ export function getRules() {
             class: 'auto_complete_description_label',
             'font.italic': true,
         },
+
+        // KIND INFO
         {
-            class: 'auto_complete_hint',
-            opacity: 0.7,
-            'font.italic': true,
-        },
-        {
-            class: 'table_row',
-            'layer0.tint': 'var(autoCompleteSelectedBackground)',
+            class: 'kind_container',
             'layer0.opacity': 0,
+            'layer1.opacity': 0,
         },
         {
-            class: 'table_row',
-            attributes: ['selected'],
-            'layer0.opacity': 1.0,
+            class: 'kind_label',
+            'font.bold': false,
+            'font.italic': false,
         },
 
         // BUTTON CONTROL


### PR DESCRIPTION
This PR...

1. ensures background of auto-completion panel to always follow theme colors rather than color scheme background.
2. creates a 1px border around the auto-completion popup
3. tweaks kind_info by removing background color and rendering kind labels without bold and italic modifiers. Looks more elegant and works better with emojis and various unicode glyphs.