### PR TITLE
Fix edit_line_control height

### DIFF
--- a/Github.hidden-theme
+++ b/Github.hidden-theme
@@ -1088,7 +1088,7 @@
             "layer1.draw_center": false,
             "content_margin": [
                 8,
-                12
+                10
             ],
             "color_scheme_tint": "var(inputBackground)"
         },

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -920,7 +920,7 @@ export function getRules() {
             'layer1.opacity': 1.0,
             'layer1.inner_margin': 1,
             'layer1.draw_center': false,
-            content_margin: [8, 12],
+            content_margin: [8, 10],
             color_scheme_tint: 'var(inputBackground)',
         },
 


### PR DESCRIPTION
This PR reduces line height of edit controls by 2px so it matches find/replace buttons' height in find/replace panel. Both input controls and buttons using same height creates most consistent user experience.